### PR TITLE
Update README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -83,7 +83,7 @@ Here are a few examples:
 
 * **Personal customizations** &mdash; Have every system come up running with your own customizations such as your favorite .bashrc and any other files that you always want on your system
 
-* **Append Custom fstab file to /etc/fstab** &mdash; Automatically append your site-specific fstab entries to /etc/fstab
+* **[Append Custom fstab file to /etc/fstab](https://github.com/gitbls/sdm/wiki/fstab)** &mdash; Automatically append your site-specific fstab entries to /etc/fstab
 
 * **systemd service configuration and management** &mdash; If there are services that you always enable or disable, you can easily configure them with sdm
 


### PR DESCRIPTION
In the 'What else can sdm do?' section, added a link to the Wiki page that explains appending lines to /etc/fstab.  I sometimes find it difficult to find the appropriate details for topics/concepts and have thought that it would be very useful to have such links right where the topic is introduced in the excellent overview README.  Rather than just ask for such a thing, I thought I would try to contribute in a small way.  I am pretty new to Github so I'm submitting this as a sort of test case.  If it's useful and properly done, I can add more such links as I work through my setup and use of sdm.